### PR TITLE
add plotlylightq type for Weave

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QuizQuestions"
 uuid = "612c44de-1021-4a21-84fb-7261cf5eb2d4"
 authors = ["jverzani <jverzani@gmail.com> and contributors"]
-version = "0.3.8"
+version = "0.3.9"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -181,6 +181,13 @@ hotspotq(imgfile, (0,0), (1/2, 1/2),
     label="What best matches the graph of ``f(x) = -x^4``?")
 ```
 
+----
+
+The `PlotlyLight` package provides a very lightweight interface for producing JavaScript based graphs with the `plotly.js` library. The `plotlylight` allows questions involving an `(x,y)` selection from a graph.
+
+Unfortunately, this only seems to work from within `Weave.jl`.
+
+
 ## Reference
 
 The available question types are listed below. If others are desirable, open an issue on the GitHub repository.
@@ -196,4 +203,5 @@ numericq
 stringq
 fillblankq
 hotspotq
+plotlylightq
 ```

--- a/src/QuizQuestions.jl
+++ b/src/QuizQuestions.jl
@@ -13,6 +13,6 @@ export numericq,
     buttonq, radioq, booleanq, yesnoq,
     multiq,  matchq,
     stringq, fillblankq,
-    hotspotq
+    hotspotq, plotlylightq
 
 end

--- a/src/html_templates.jl
+++ b/src/html_templates.jl
@@ -247,3 +247,17 @@ html_templates["hotspot_grading_script"] = """
 
   })
 """
+
+## -----
+## -------
+html_templates["plotlylight_grading_script"] = """
+document.getElementById("{{{:ID}}}").on("plotly_click", function(e) {
+      x = e.points[0].x
+      y = e.points[0].y
+
+      correct = {{{:CORRECT_ANSWER}}}
+      var msgBox = document.getElementById('{{:ID}}_message');
+      $(grading_partial)
+
+  })
+"""

--- a/src/question_types.jl
+++ b/src/question_types.jl
@@ -443,3 +443,59 @@ function hotspotq(imgfile, xy, ΔxΔy;
                   correct_answer=nothing)
     HotspotQ(imgfile, xy, ΔxΔy, label, hint, explanation, correct_answer)
 end
+
+
+## ----
+mutable struct PlotlyLightQ <: Question
+    p
+    xs
+    ys
+    label
+    hint
+    explanation
+    correct_answer
+end
+
+"""
+    plotlylightq(p, xs=(-Inf, Inf), ys=(-Inf, Inf);
+                 label="", hint="", explanation="",
+                 correct_answer=nothing)
+
+Display a `PlotlyLight` graph. By default, correct answers select a value on the graph with `x` in the range specified by `xs` and `y` in the range specified by `ys`.
+
+* `xs`: specifies interval for selected pont `[x₀,x₁]`, defaults = `(-Inf,Inf)`
+* `ys`: range `[y₀,y₁]`
+* `correct_answer`: when speficied, allows more advanced notions of correct. This is a JavaScript code snippet with `x` and `y` representing the point on the graph that is clicked on.
+
+## Examples
+
+```
+using PlotlyLight # not loaded by default
+xs = range(0, 2pi, length=100)
+ys = sin.(xs)
+p = Plot(Config(x=xs, y=ys))
+plotlylightq(p, (3,Inf); label="Click a value with ``x>3``")
+```
+
+An example where the default grading script needs modification. Note also, the `x`, `y` values refer to the *first* graph. (One could modify their definition in `correct answer`; they are found through `x=e.points[0].x`, `y=e.points[0].y`.)
+
+```
+xs = range(0, 2pi, length=100)
+ys = sin.(xs)
+p = Plot(Config(x=xs, y=ys))
+push!(p.data, Config(x=xs, y=cos.(xs)));
+question = "Click a value where `sin(x)` is increasing"
+# evalute pi/2 as no pi in JavaScript, also Inf -> Infinity
+correct_answer = "((x >= 0 && x <= $(pi/2)) || (x >= $(3pi/2) && x <= $(2pi)))"
+plotlylightq(p, (3,Inf); label=question, correct_answer=correct_answer)
+```
+
+!!! note
+    The use of `PlotlyLight` graphics works with `Weave`, but is unusable from `Documenter`.
+
+"""
+function plotlylightq(p, xs=(-Inf, Inf), ys=(-Inf,Inf);
+                  label = "", hint="", explanation="",
+                  correct_answer=nothing)
+    PlotlyLightQ(p, xs, ys, label, hint, explanation, correct_answer)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,4 +28,7 @@ using Test
     r = hotspotq("empty", (0,0), (1,1); explanation="XXX")
     @test r.explanation == "XXX"
 
+    r = plotlylightq("empty"; label="XXX")
+    @test r.label == "XXX"
+
 end


### PR DESCRIPTION
* Add a `plotlylightq` type to test `(x,y)` selection from a plot. 
* Doesn't work within Documenter; does from `Weave`
* Limited to selection from a single plot unless user adds in some JavaScript