### PR TITLE
Small fixes

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -238,4 +238,5 @@ stringq
 fillblankq
 hotspotq
 plotlylightq
+scorecard
 ```

--- a/src/question_types.jl
+++ b/src/question_types.jl
@@ -2,6 +2,7 @@ abstract type Question end
 
 mutable struct Stringq <: Question
     re::Regex
+    filter::Regex
     label
     hint
     explanation
@@ -9,13 +10,15 @@ mutable struct Stringq <: Question
 end
 
 """
-    stringq(re::Regex; label="", hint="", explanation="", placeholder="")
+    stringq(re::Regex; filter::Regex=r"", label="", hint="", explanation="", placeholder="")
 
 Match string answer with regular expression
 
 Arguments:
 
 * `re`: a regular expression for grading
+
+* `filter`: a regular expression for what to remove from the string before matching (e.g. `r"\\s"` to remove whitespace)
 
 * `label`: optional label for the form element
 
@@ -33,8 +36,8 @@ stringq(re, label="First 3 letters...")
 ```
 
 """
-stringq(re::Regex; label="", hint="", explanation="",  placeholder=nothing) =
-    Stringq(re, label, hint, explanation, placeholder)
+stringq(re::Regex; filter::Regex=r"", label="", hint="", explanation="",  placeholder=nothing) =
+    Stringq(re, filter, label, hint, explanation, placeholder)
 
 
 ##

--- a/src/question_types.jl
+++ b/src/question_types.jl
@@ -57,7 +57,7 @@ Arguments:
 
 * `value`: the numeric answer
 
-* `atol`: ``|answer - value| \\le atol`` is used to determine correctness
+* `atol`: ``|\\mathrm{answer} - \\mathrm{value}| \\le \\mathrm{atol}`` is used to determine correctness
 
 * `label`: optional label for the form element
 

--- a/src/show_methods.jl
+++ b/src/show_methods.jl
@@ -81,7 +81,7 @@ function prepare_question(x::Stringq, ID)
     GRADING_SCRIPT =
         Mustache.render(html_templates["input_grading_script"];
                         ID = ID,
-                        CORRECT_ANSWER = """RegExp('$(x.re.pattern)').test(this.value)""",
+                        CORRECT_ANSWER = """RegExp('$(x.re.pattern)').test(this.value.replaceAll(RegExp('$(x.filter.pattern)', 'g'), ''))""",
                         INCORRECT = "Incorrect",
                         CORRECT = "Correct"
                         )


### PR DESCRIPTION
1. add `scorecard` to documentation generation
2. add `\mathrm` to documentation for `numericq.atol`
3. add a `filter` option to `stringq` to help trim whitespace, commas, parantheses, etc.