### PR TITLE
Add qq* classes; configure buttonq colors

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QuizQuestions"
 uuid = "612c44de-1021-4a21-84fb-7261cf5eb2d4"
 authors = ["jverzani <jverzani@gmail.com> and contributors"]
-version = "0.3.24"
+version = "0.3.25"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/html_templates.jl
+++ b/src/html_templates.jl
@@ -3,29 +3,39 @@ html_templates = Dict()
 
 # code to support scorecard widget
 scorecard_correct_partial = """
-  const correct_answer   = new CustomEvent("quizquestion_answer", {bubbles:true, detail:{correct: 1}});
+  const correct_answer   = new CustomEvent("quizquestion_answer",
+          {bubbles:true, detail:{correct: 1}}
+  );
   this.dispatchEvent(correct_answer);
-  //typeof correct_answer   != "undefined" && this.dispatchEvent(correct_answer);
 """
 
 scorecard_incorrect_partial = """
-  const incorrect_answer = new CustomEvent("quizquestion_answer", {bubbles:true, detail:{correct: 0}});
+  const incorrect_answer = new CustomEvent("quizquestion_answer",
+           {bubbles:true, detail:{correct: 0}}
+  );
   this.dispatchEvent(incorrect_answer);
-  //typeof incorrect_answer != "undefined" && this.dispatchEvent(incorrect_answer);
 """
 
 # thumbs up/down don't show in my editor
 grading_partial = """
 
   if(correct) {
-    msgBox.innerHTML = "<div class='pluto-output admonition note alert alert-success'><span> 👍&nbsp; {{#:CORRECT}}{{{:CORRECT}}}{{/:CORRECT}}{{^:CORRECT}}Correct{{/:CORRECT}} </span></div>";
+    msgBox.innerHTML = "<div class='pluto-output admonition note alert alert-success'> \
+       <span> 👍&nbsp; \
+       {{#:CORRECT}}{{{:CORRECT}}}{{/:CORRECT}}{{^:CORRECT}}Correct{{/:CORRECT}} \
+       </span> \
+    </div>";
     var explanation = document.getElementById("explanation_{{:ID}}")
     if (explanation != null) {
        explanation.style.display = "none";
     }
     $(scorecard_correct_partial)
   } else {
-    msgBox.innerHTML = "<div class='pluto-output admonition alert alert-danger'><span>👎&nbsp; {{#:INCORRECT}}{{{:INCORRECT}}}{{/:INCORRECT}}{{^:INCORRECT}}Incorrect{{/:INCORRECT}} </span></div>";
+    msgBox.innerHTML = "<div class='pluto-output admonition alert alert-danger'> \
+         <span>👎&nbsp; \
+         {{#:INCORRECT}}{{{:INCORRECT}}}{{/:INCORRECT}}{{^:INCORRECT}}Incorrect{{/:INCORRECT}} \
+         </span> \
+    </div>";
     var explanation = document.getElementById("explanation_{{:ID}}")
     if (explanation != null) {
        explanation.style.display = "block";
@@ -42,25 +52,39 @@ html_templates["question_tpl"] = mt"""
 <script>
 var ID = "{{:ID}}"
 </script>
-<form class="mx-2 my-3 mw-100" name='WeaveQuestion' data-id='{{:ID}}' data-controltype='{{:TYPE}}' onSubmit='return false;'>
+<form class="mx-2 my-3 mw-100 qqquestion"
+      name='WeaveQuestion'
+      data-id='{{:ID}}'
+      data-controltype='{{:TYPE}}'
+      onSubmit='return false;'
+      >
   <div class='form-group {{:STATUS}}'>
     <div class='controls'>
       <div class="form" id="controls_{{:ID}}" correct='-1' attempts='0'>
     {{#:LABEL}}
     {{{:LABEL}}}
-            {{#:HINT}}<span href="#" title="{{{:HINT}}}">&nbsp;🎁</span>{{/:HINT}}
+    {{#:HINT}}<span href="#" title="{{{:HINT}}}">&nbsp;🎁</span>{{/:HINT}}
     {{/:LABEL}}
-        <div style="padding-top: 5px">
+
+    <div style="padding-top: 5px">
     {{{:FORM}}}
-    {{^:LABEL}}{{#:HINT}}<label for="controls_{{:ID}}"><span href="#" title="{{{:HINT}}}">&nbsp;🎁</span></label>{{/:HINT}}{{/:LABEL}}
-        </div>
-      </div>
-      <div id='{{:ID}}_message' style="padding-bottom: 15px"></div>
-      {{#:EXPLANATION}}
-      <div id="explanation_{{:ID}}" class='pluto-output admonition alert alert-danger' style="display:none;;background-color:#D3D3D366;">{{{:EXPLANATION}}}</div>
-      {{/:EXPLANATION}}
+    {{^:LABEL}}
+    {{#:HINT}}<label for="controls_{{:ID}}"><span href="#" title="{{{:HINT}}}">&nbsp;🎁</span></label>
+    {{/:HINT}}
+    {{/:LABEL}}
+     </div>
     </div>
-  </div>
+    <div id='{{:ID}}_message'
+         class='qqmessage'
+         style="padding-bottom: 15px">
+    {{#:EXPLANATION}}
+     <div id="explanation_{{:ID}}"
+          class='pluto-output admonition alert alert-danger qqexplanation'
+          style="display:none;background-color:{{:EXPLANATION_BG}};">
+     {{{:EXPLANATION}}}
+     </div>
+     {{/:EXPLANATION}}
+    </div>
 </form>
 <script>
 document.getElementById('controls_{{:ID}}').addEventListener("quizquestion_answer", (e) => {
@@ -96,13 +120,20 @@ document.getElementById("{{:ID}}").addEventListener("change", function() {
 ##
 html_templates["inputq_form"] = mt"""
 </br>
-<div class="input-group" aria-label="Input form: {{:PLACEHOLDER}}">
-    <input id="{{:ID}}" type="{{:TYPE}}" class="form-control" placeholder="{{:PLACEHOLDER}}" aria-label="{{:PLACEHOLDER}}">
+<div class="input-group"
+     aria-label="Input form: {{:PLACEHOLDER}}">
+    <input id="{{:ID}}"
+           type="{{:TYPE}}"
+           class="form-control qqinput"
+           placeholder="{{:PLACEHOLDER}}"
+           aria-label="{{:PLACEHOLDER}}">
     {{#:UNITS}}
     <span class="input-group-append">&nbsp;{{{:UNITS}}}&nbsp;</span>
     {{/:UNITS}}
     {{#:HINT}}
-    <span  class="input-group-append" href="#" title="{{{:HINT}}}">&nbsp;🎁</span>
+    <span  class="input-group-append"
+           href="#"
+            title="{{{:HINT}}}">&nbsp;🎁</span>
     {{/:HINT}}
 </div>
 """
@@ -113,16 +144,21 @@ html_templates["inputq_form"] = mt"""
 ## We do *not* use sibling elements, as suggested by Bootstrap here
 html_templates["Radioq"] = mt"""
 <fieldset style="border:0px">
-<legend style="display: none" aria-label="Select an item">Select an item</legend>
+<legend style="display: none"
+        aria-label="Select an item">Select an item</legend>
 {{#:ITEMS}}
 <div class="form-check">
-    <label class="form-check-label" for="radio_{{:ID}}_{{:VALUE}}">
-      <input class="form-check-input" type="radio" name="radio_{{:ID}}"
-              id="radio_{{:ID}}_{{:VALUE}}" value="{{:VALUE}}">
-      </input>
-      <span class="label-body px-1">
+    <label class="form-check-label qqradio"
+           for="radio_{{:ID}}_{{:VALUE}}">
+    <input class="form-check-input"
+           type="radio"
+           name="radio_{{:ID}}"
+           id="radio_{{:ID}}_{{:VALUE}}"
+           value="{{:VALUE}}">
+    </input>
+    <span class="label-body px-1">
         {{{:LABEL}}}
-      </span>
+    </span>
     </label>
 </div>
 {{/:ITEMS}}
@@ -139,9 +175,16 @@ rb.addEventListener("change", function() {
 """
 ## ----
 html_templates["Buttonq"] = jmt"""
-<div id="buttongroup_{{:ID}}" class="btn-group-vertical w-100">
+<div id="buttongroup_{{:ID}}"
+     class="btn-group-vertical w-100">
   {{#:BUTTONS}}
-  <button type="button" class="btn toggle-btn px-4 my-1 btn-light btn-block active" aria-pressed="false" id="button_{{:ID}}_{{:i}}" value="{{:ANSWER}}" style="width:100%;text-align:left; padding-left:10px; {{#:BLUE}}background:{{{:BLUE}}}{{/:BLUE}}" onclick="return false;">
+  <button type="button"
+          class="btn toggle-btn px-4 my-1 btn-light btn-block active qqbutton"
+          aria-pressed="false"
+          id="button_{{:ID}}_{{:i}}"
+          value="{{:ANSWER}}"
+          style="width:100%;text-align:left; padding-left:10px; {{#:BLUE}}background:{{{:BLUE}}}{{/:BLUE}}"
+          onclick="return false;">
     {{{:TEXT}}
   </button>
   {{/:BUTTONS}}
@@ -187,8 +230,11 @@ html_templates["Multiq"] = mt"""
 {{#:ITEMS}}
 <div class="form-check">
   <label>
-    <input class="form-check-input" type="checkbox" name="check_{{:ID}}"
-              id="check_{{:ID}}_{{:VALUE}}" value="{{:VALUE}}">
+    <input class="form-check-input qqmulti"
+           type="checkbox"
+           name="check_{{:ID}}"
+           id="check_{{:ID}}_{{:VALUE}}"
+           value="{{:VALUE}}">
       <span class="label-body">
         {{{:LABEL}}}
       </span>
@@ -218,17 +264,25 @@ rb.addEventListener("change", function() {
 """
 
 html_templates["MultiButtonq"] = mt"""
-<div id="buttongroup_{{:ID}}" class="btn-group-vertical w-100">
+<div id="buttongroup_{{:ID}}"
+     class="btn-group-vertical w-100">
   {{#:BUTTONS}}
-  <button type="button" class="btn toggle-btn px-4 my-1  btn-light btn-block active" aria-pressed="false"
-    id="button_{{:ID}}_{{:i}}" name="{{:i}}" value="unclicked"
-    style="width:100%;text-align:left; padding-left:10px; {{#:BLUE}}background:{{{:BLUE}}}{{/:BLUE}}" onclick="return false;">
-      {{{:TEXT}}
+  <button type="button"
+          class="btn toggle-btn px-4 my-1  btn-light btn-block active qqmultibutton"
+          aria-pressed="false"
+          id="button_{{:ID}}_{{:i}}"
+          name="{{:i}}"
+          value="unclicked"
+          style="width:100%;text-align:left; padding-left:10px; {{#:BLUE}}background:{{{:BLUE}}}{{/:BLUE}}"
+          onclick="return false;">
+       {{{:TEXT}}
   </button>
   {{/:BUTTONS}}
   <div class="col mt-1 align-self-center">
-  <button id="button_{{:ID}}-done" class="btn btn-primary"
-     style="display:block; margin:auto;text-align:center;{{#:BLUE}}background:{{{:BLUE}}}{{/:BLUE}}" onclick="return false;">
+  <button id="button_{{:ID}}-done"
+          class="btn btn-primary"
+          style="display:block; margin:auto;text-align:center;{{#:BLUE}}background:{{{:BLUE}}}{{/:BLUE}}"
+          onclick="return false;">
       DONE
   </button>
   </div>
@@ -299,11 +353,13 @@ html_templates["Matchq"] = mt"""
 {{#:ITEMS}}
 
 <div>
-  <select name = "select_{{:ID}}" id="select_{{:ID}}" aria-label="Select one">
+  <select name="select_{{:ID}}"
+          id="select_{{:ID}}"
+          aria-label="Select one">
      <option value=0 selected="selected">{{{:BLANK}}}</option>
      {{#:ANSWER_CHOICES}}
      <option value="{{:INDEX}}">{{{:LABEL}}}</option>
-    {{/:ANSWER_CHOICES}}
+     {{/:ANSWER_CHOICES}}
   </select>
 </div>
 <div>{{{:QUESTION}}}</div>
@@ -335,25 +391,36 @@ html_templates["matchq_grading_script"] = """
 ## ----
 
 html_templates["fill_in_blank_select"] = """
-  <select name = "select_{{:ID}}" id="select_{{:ID}}" aria-label"Make a selection">
-     <option value="0" selected="selected">{{{:BLANK}}}</option>
+  <select name="select_{{:ID}}"
+          id="select_{{:ID}}"
+          aria-label="Make a selection"> TTT
+     <option value="0"
+             selected="selected">{{{:BLANK}}}</option>
      {{#:ANSWER_CHOICES}}
      <option value="{{:INDEX}}">{{{:LABEL}}}</option>
     {{/:ANSWER_CHOICES}}
   </select>
-<label for="select_{{:ID}}" style="left: -100vw; position: absolute;">Make a selection</label>
+<label for="select_{{:ID}}"
+       style="left: -100vw; position: absolute;">Make a selection</label>
 """
 
 html_templates["fill_in_blank_input"] = """
-<input id="{{:ID}}" type="{{:TYPE}}" class="form-{{^:INLINE}}control{{/:INLINE}}" placeholder="{{:PLACEHOLDER}}" aria-label="Fill in the blank">
-<label for="{{:ID}}" style="left: -100vw; position: absolute;">Fill in the blank</label>
+<input id="{{:ID}}"
+       type="{{:TYPE}}"
+       class="form-{{^:INLINE}}control{{/:INLINE}} qqfillinblank"
+       placeholder="{{:PLACEHOLDER}}"
+       aria-label="Fill in the blank">
+<label for="{{:ID}}"
+       style="left: -100vw; position: absolute;">Fill in the blank</label>
 """
 
 
 ## -------
 html_templates["hotspot"] = """
 <div aria-label="Hotspot question for selection from an image">
-<img  id="hotspot_{{{:ID}}}" alt="Image for hotspot selection" src="data:image/gif;base64,{{{:IMG}}}" />
+<img id="hotspot_{{{:ID}}}"
+     alt="Image for hotspot selection"
+     src="data:image/gif;base64,{{{:IMG}}}" />
 </div>
 """
 

--- a/src/html_templates.jl
+++ b/src/html_templates.jl
@@ -197,7 +197,7 @@ document.querySelectorAll('[id^="button_{{:ID}}_"]').forEach(function(btn) {
 
 	if (!correct) {
             $(scorecard_incorrect_partial)
-	    {{#:GREEN}}this.style.background = "{{{:GREEN}}}";{{/:GREEN}}
+	    {{#:RED}}this.style.background = "{{{:RED}}}";{{/:RED}}
 	    var text = this.innerHTML;
 	    this.innerHTML = "<em>{{{:INCORRECT}}</em>&nbsp;" + text ;
             var explanation = document.getElementById("explanation_{{:ID}}")
@@ -211,7 +211,7 @@ document.querySelectorAll('[id^="button_{{:ID}}_"]').forEach(function(btn) {
 	    btn.disabled = true;
             btn.setAttribute("aria-pressed", "true");
 	    if (btn.value == "correct") {
-                {{#:RED}}btn.style.background = "{{{:RED}}}";{{/:RED}}
+                {{#:GREEN}}btn.style.background = "{{{:GREEN}}}";{{/:GREEN}}
 		var text = btn.innerHTML;
 		btn.innerHTML =  " <em>{{{:CORRECT}}}</em>&nbsp;" + text ;
 		btn.style.fontSize = "1.1rem";

--- a/src/html_templates.jl
+++ b/src/html_templates.jl
@@ -21,7 +21,7 @@ grading_partial = """
 
   if(correct) {
     msgBox.innerHTML = "<div class='pluto-output admonition note alert alert-success'> \
-       <span> 👍&nbsp; \
+       <span>✔&nbsp; \
        {{#:CORRECT}}{{{:CORRECT}}}{{/:CORRECT}}{{^:CORRECT}}Correct{{/:CORRECT}} \
        </span> \
     </div>";
@@ -32,7 +32,7 @@ grading_partial = """
     $(scorecard_correct_partial)
   } else {
     msgBox.innerHTML = "<div class='pluto-output admonition alert alert-danger'> \
-         <span>👎&nbsp; \
+         <span>Χ&nbsp; \
          {{#:INCORRECT}}{{{:INCORRECT}}}{{/:INCORRECT}}{{^:INCORRECT}}Incorrect{{/:INCORRECT}} \
          </span> \
     </div>";

--- a/src/question_types.jl
+++ b/src/question_types.jl
@@ -192,6 +192,17 @@ mutable struct Buttonq <: Question
     colors
 end
 
+const old_colors = (GREEN="#FF0000AA",
+              RED = "#00AA33AA",
+              BLUE = nothing)
+
+#https://github.com/JuliaLang/julia-logo-graphics/blob/master/images/julia-colors.svg
+#https://gist.github.com/lopspower/03fb1cc0ac9f32ef38f4
+const julia_colors = (GREEN="#3898261A",
+                      RED = "#CB3C331A",
+                      BLUE = "#4063D81A",
+                      PURPLE = "#9558B21A")
+#D3D3D366 was this bg color
 """
     buttonq(choices, answer; label="", hint="", [colors])
 
@@ -209,6 +220,7 @@ Arguments:
 
 * `explanation`: text to display on a wrong selection
 
+* `colors` a named tuple with colors for `GREEN`, `RED`, and `BLUE`
 
 ## Example:
 
@@ -222,9 +234,7 @@ buttonq(choices, answer; label="Which is the Greek symbol?",
 """
 function buttonq(choices, answer::Integer;
                  label="", hint="", explanation="",
-                 colors=(GREEN="#FF0000AA",
-                         RED = "#00AA33AA",
-                         BLUE = nothing) #"#0033CC11",
+                 colors=julia_colors
                  )
 
     answers = [i == answer ? "correct" : "incorrect" for i ∈ eachindex(choices)]

--- a/src/show_methods.jl
+++ b/src/show_methods.jl
@@ -24,7 +24,7 @@ function _markdown_to_html(x)
     length(x) == 0 && return("")
     x = Markdown.parse(x)
     x = sprint(io -> Markdown.html(io, x))
-    x = replace(x, r"\n<p>"=>" ", r"</p>$"=>" ")
+    x = replace(x, r"<p>"=>" ", r"</p>$"=>" ")
     return x
 end
 
@@ -42,6 +42,7 @@ function Base.show(io::IO, m::MIME"text/html", x::Question)
                     LABEL=_markdown_to_html(x.label),
                     HINT = length(x.label) > 0 ? x.hint : "",
                     EXPLANATION = _markdown_to_html(x.explanation),
+                    EXPLANATION_BG = julia_colors.PURPLE, #"#D39558B2", TODO: confiugrable
                     FORM = FORM,
                     GRADING_SCRIPT = GRADING_SCRIPT
                     )


### PR DESCRIPTION
A start on addressing issue #53 by adding different `qqXXX` class tags to form elements. For example, `qqmessage` might be used as a selector to adjust the message placement.

Also modified color scheme of `buttonq` to use Julia logo colors